### PR TITLE
Expose `get_robot_model()` with F_T_EE baked into URDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] - 2026-03-17
+
+### Added
+- Expose `get_robot_model()` — returns the robot's URDF with `F_T_EE` (flange-to-end-effector transform) baked in as a fixed joint, so the URDF matches the full kinematic chain used by the driver's runtime IK.
+
 ## [0.3.1] - 2026-02-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "positronic-franka"
-version = "0.3.1"
+version = "0.4.0"
 description = "Python interface to Franka robots for Positronic project"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -124,5 +124,5 @@ PYBIND11_MODULE(_franka, m) {
       .def("recover_from_errors", &positronic_franka::Robot::recover_from_errors,
            "Stop active control and attempt libfranka automaticErrorRecovery(); returns True if cleared")
       .def("get_robot_model", [](positronic_franka::Robot& r) { return r.getRobotModel(); },
-           "Return MuJoCo XML model of the robot for offline IK computation");
+           "Return URDF of the robot with F_T_EE (end-effector frame) appended for offline IK");
 }

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -122,5 +122,7 @@ PYBIND11_MODULE(_franka, m) {
            py::arg("mass"), py::arg("F_x_Cload"), py::arg("I_x_Cload"),
            "Set tool load: mass [kg], center of mass (3,), inertia (row-major 3x3)")
       .def("recover_from_errors", &positronic_franka::Robot::recover_from_errors,
-           "Stop active control and attempt libfranka automaticErrorRecovery(); returns True if cleared");
+           "Stop active control and attempt libfranka automaticErrorRecovery(); returns True if cleared")
+      .def("get_robot_model", [](positronic_franka::Robot& r) { return r.getRobotModel(); },
+           "Return MuJoCo XML model of the robot for offline IK computation");
 }

--- a/src/robot.hpp
+++ b/src/robot.hpp
@@ -667,7 +667,7 @@ private:
     // This accounts for the mounted gripper/tool and is used by libfranka's
     // model->pose(kEndEffector) for FK and IK. The base URDF from
     // robot->getRobotModel() only describes kinematics up to the flange
-    // (panda_link8), so we append a fixed joint + link to complete the chain.
+    // (link8), so we append a fixed joint + link to complete the chain.
     auto state = read_robot_state_();
     Eigen::Map<const Eigen::Matrix4d> F_T_EE(state.F_T_EE.data());
     const Eigen::Vector3d t = F_T_EE.block<3, 1>(0, 3);
@@ -676,6 +676,21 @@ private:
     // URDF fixed-axis RPY (extrinsic XYZ = intrinsic ZYX reversed)
     const Eigen::Vector3d zyx = R.eulerAngles(2, 1, 0);
     const double roll = zyx(2), pitch = zyx(1), yaw = zyx(0);
+
+    // Find the flange link name dynamically (last <link name="..."> before </robot>).
+    // Panda URDFs use "panda_link8", FR3 URDFs use "link8".
+    std::string flange_link = "link8";
+    auto robot_end = urdf.rfind("</robot>");
+    if (robot_end != std::string::npos) {
+      auto last_link = urdf.rfind("<link name=\"", robot_end);
+      if (last_link != std::string::npos) {
+        auto name_start = last_link + 12;  // length of '<link name="'
+        auto name_end = urdf.find('"', name_start);
+        if (name_end != std::string::npos) {
+          flange_link = urdf.substr(name_start, name_end - name_start);
+        }
+      }
+    }
 
     std::ostringstream snippet;
     snippet << std::setprecision(10)
@@ -687,15 +702,14 @@ private:
             << "       matches the full kinematic chain used by the driver's runtime IK. -->\n"
             << "  <link name=\"end_effector\"/>\n"
             << "  <joint name=\"flange_to_end_effector\" type=\"fixed\">\n"
-            << "    <parent link=\"panda_link8\"/>\n"
+            << "    <parent link=\"" << flange_link << "\"/>\n"
             << "    <child link=\"end_effector\"/>\n"
             << "    <origin xyz=\"" << t.x() << " " << t.y() << " " << t.z() << "\""
             << " rpy=\"" << roll << " " << pitch << " " << yaw << "\"/>\n"
             << "  </joint>\n";
 
-    auto pos = urdf.rfind("</robot>");
-    if (pos != std::string::npos) {
-      urdf.insert(pos, snippet.str());
+    if (robot_end != std::string::npos) {
+      urdf.insert(robot_end, snippet.str());
     }
     return urdf;
   }

--- a/src/robot.hpp
+++ b/src/robot.hpp
@@ -8,7 +8,9 @@
 #include <array>
 #include <cmath>
 #include <algorithm>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <atomic>
@@ -659,7 +661,43 @@ private:
   }
 
   std::string getRobotModel() {
-    return robot_->getRobotModel();
+    std::string urdf = robot_->getRobotModel();
+
+    // Read F_T_EE (flange-to-end-effector transform) from current robot state.
+    // This accounts for the mounted gripper/tool and is used by libfranka's
+    // model->pose(kEndEffector) for FK and IK. The base URDF from
+    // robot->getRobotModel() only describes kinematics up to the flange
+    // (panda_link8), so we append a fixed joint + link to complete the chain.
+    auto state = read_robot_state_();
+    Eigen::Map<const Eigen::Matrix4d> F_T_EE(state.F_T_EE.data());
+    const Eigen::Vector3d t = F_T_EE.block<3, 1>(0, 3);
+    const Eigen::Matrix3d R = F_T_EE.block<3, 3>(0, 0);
+
+    // URDF fixed-axis RPY (extrinsic XYZ = intrinsic ZYX reversed)
+    const Eigen::Vector3d zyx = R.eulerAngles(2, 1, 0);
+    const double roll = zyx(2), pitch = zyx(1), yaw = zyx(0);
+
+    std::ostringstream snippet;
+    snippet << std::setprecision(10)
+            << "\n"
+            << "  <!-- WARNING: This link and joint were appended by positronic-franka,\n"
+            << "       NOT part of the original URDF from libfranka getRobotModel().\n"
+            << "       They encode F_T_EE (flange-to-end-effector transform) read from\n"
+            << "       franka::RobotState at the time of this call, so that the URDF\n"
+            << "       matches the full kinematic chain used by the driver's runtime IK. -->\n"
+            << "  <link name=\"end_effector\"/>\n"
+            << "  <joint name=\"flange_to_end_effector\" type=\"fixed\">\n"
+            << "    <parent link=\"panda_link8\"/>\n"
+            << "    <child link=\"end_effector\"/>\n"
+            << "    <origin xyz=\"" << t.x() << " " << t.y() << " " << t.z() << "\""
+            << " rpy=\"" << roll << " " << pitch << " " << yaw << "\"/>\n"
+            << "  </joint>\n";
+
+    auto pos = urdf.rfind("</robot>");
+    if (pos != std::string::npos) {
+      urdf.insert(pos, snippet.str());
+    }
+    return urdf;
   }
 
   bool recover_from_errors() {

--- a/src/robot.hpp
+++ b/src/robot.hpp
@@ -658,6 +658,10 @@ private:
     robot_->setLoad(mass, F_x_Cload, I_x_Cload);
   }
 
+  std::string getRobotModel() {
+    return robot_->getRobotModel();
+  }
+
   bool recover_from_errors() {
     stop_control_loop_();
     stop_requested_.store(false);


### PR DESCRIPTION
## Summary
- Add `get_robot_model()` Python method that returns the robot's URDF with `F_T_EE` (flange-to-end-effector transform) appended as a fixed joint + link, so the URDF matches the full kinematic chain used by the driver's runtime IK.
- Dynamically detects the flange link name from the URDF (handles both Panda `panda_link8` and FR3 `link8` variants).
- Bumps version to 0.4.0.

## Test plan
- Requires robot hardware to verify. Call `robot.get_robot_model()` and inspect the returned URDF for the `end_effector` link and `flange_to_end_effector` joint with correct `F_T_EE` values.